### PR TITLE
Class SPDXLicense has unused ivar "licenseName"

### DIFF
--- a/src/SPDX/SPDXLicense.class.st
+++ b/src/SPDX/SPDXLicense.class.st
@@ -23,7 +23,6 @@ Class {
 		'reference',
 		'detailsUrl',
 		'referenceNumber',
-		'licenseName',
 		'isDeprecatedLicenseId',
 		'seeAlso',
 		'isOsiApproved',


### PR DESCRIPTION
Fix #1